### PR TITLE
Add ngram blocking in beam search

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1282,6 +1282,10 @@ def add_inference_args(params):
                                type=str,
                                help='EXPERIMENTAL: may be changed or removed in future. Overrides training dtype of '
                                     'encoders and decoders during inference. Default: %(default)s')
+    decode_params.add_argument('--beam-block-ngram',
+                               default=0,
+                               type=int,
+                               help='Block all repeating ngrams up to length n')
 
 
 def add_evaluate_args(params):

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -107,7 +107,8 @@ def run_translate(args: argparse.Namespace):
                                           avoid_list=args.avoid_list,
                                           store_beam=store_beam,
                                           strip_unknown_words=args.strip_unknown_words,
-                                          skip_topk=args.skip_topk)
+                                          skip_topk=args.skip_topk,
+                                          beam_block_ngram=args.beam_block_ngram)
         read_and_translate(translator=translator,
                            output_handler=output_handler,
                            chunk_size=args.chunk_size,


### PR DESCRIPTION
Add another argument to the inference model specifying a value n which is the minimum length n-gram to block from the output sentences. Hypotheses that generated repeating n-grams will be removed from the beam unless they are the only ones remaining, in which case they are left as-is (for now).