### PR TITLE
Add penalty for continuations from same hypothesis (Li, Monroe, Jurafsky 2016)

### DIFF
--- a/sockeye/arguments.py
+++ b/sockeye/arguments.py
@@ -1290,6 +1290,10 @@ def add_inference_args(params):
                                default=0,
                                type=int,
                                help='Limit the number of continuations that can come from a single hypothesis.')
+    decode_params.add_argument('--beam-sibling-penalty',
+                               default=0,
+                               type=float,
+                               help='Penalize lower-ranked continuations from the same hypothesis.')
 
 
 def add_evaluate_args(params):

--- a/sockeye/translate.py
+++ b/sockeye/translate.py
@@ -112,7 +112,8 @@ def run_translate(args: argparse.Namespace):
                                           strip_unknown_words=args.strip_unknown_words,
                                           skip_topk=args.skip_topk,
                                           beam_block_ngram=args.beam_block_ngram,
-                                          single_hyp_max=args.single_hyp_max)
+                                          single_hyp_max=args.single_hyp_max,
+                                          beam_sibling_penalty=args.beam_sibling_penalty)
         read_and_translate(translator=translator,
                            output_handler=output_handler,
                            chunk_size=args.chunk_size,


### PR DESCRIPTION
Adds a --beam-sibling-penalty decoding parameter (should be a float between 0-1) that penalizes lower-ranked siblings from the same hypothesis.